### PR TITLE
feat: add mutated boolean to batch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2148,6 +2148,11 @@
                 "jest-diff": "^24.3.0"
             }
         },
+        "@types/json-schema": {
+            "version": "7.0.11",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+        },
         "@types/minimatch": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     },
     "pre-commit": [
         "lint",
+        "bootstrap",
+        "build",
         "test"
     ],
     "private": true,

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -105,6 +105,7 @@ export interface Batch {
     device_info?: DeviceInformation;
     application_info?: ApplicationInformation;
     user_attributes?: { [key: string]: string | string[] };
+    mutated?: boolean;
     deleted_user_attributes?: string[];
     user_identities?: BatchUserIdentities;
     environment: BatchEnvironmentEnum;


### PR DESCRIPTION
## Summary
Add `mutated` boolean to batch in order to implement `onCreateBatch` config item in core SDK.  If a batch is mutated, the `mutated` batch will be `true`.

## Testing Plan
@alexs-mparticle - there seem to be other failing tests unrelated to this.  Have you experienced this when committing to this repo?

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-4036