### PR TITLE
feat: Add active_time_on_site_ms and partner_identities to DTO

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,12 +8,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: NPM install
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v4
               with:
-                  node-version: 12.x
+                  node-version: 22.x
 
             - name: Run NPM CI
               run: npm ci
@@ -31,7 +31,7 @@ jobs:
               run: npm run test
 
             - name: Archive npm failure logs
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               if: failure()
               with:
                 name: npm-logs

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -125,6 +125,7 @@ export interface Batch {
     consent_state?: ConsentState;
     job_id?: string;
     context?: Context;
+    partner_identities?: { [key: string]: string };
 }
 
 /**

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -271,6 +271,7 @@ export interface CommonEventData {
     is_main_thread?: boolean;
     canonical_name?: string;
     event_system_notification_info?: EventSystemNotificationInfo;
+    active_time_on_site_ms?: number;
 }
 
 export interface ConsentState {

--- a/packages/events/tests/index.spec.ts
+++ b/packages/events/tests/index.spec.ts
@@ -334,6 +334,7 @@ describe('Event Server Models', () => {
                 view_controller: 'tv remote',
                 is_main_thread: false,
                 canonical_name: 'skywalker',
+                active_time_on_site_ms: 1000,
                 event_system_notification_info: {
                     type: 'gdpr_change',
                 },
@@ -497,6 +498,7 @@ describe('Event Server Models', () => {
                 view_controller: 'tv remote',
                 is_main_thread: false,
                 canonical_name: 'skywalker',
+                active_time_on_site_ms: 1000,
                 event_system_notification_info: {
                     type: 'gdpr_change',
                 },
@@ -534,6 +536,7 @@ describe('Event Server Models', () => {
                 view_controller: 'tv remote',
                 is_main_thread: false,
                 canonical_name: 'skywalker',
+                active_time_on_site_ms: 1000,
                 event_system_notification_info: {
                     type: 'gdpr_change',
                 },
@@ -654,6 +657,7 @@ describe('Event Server Models', () => {
                 view_controller: 'tv remote',
                 is_main_thread: false,
                 canonical_name: 'skywalker',
+                active_time_on_site_ms: 1000,
                 event_system_notification_info: {
                     type: 'gdpr_change',
                 },
@@ -687,6 +691,7 @@ describe('Event Server Models', () => {
                 view_controller: 'tv remote',
                 is_main_thread: false,
                 canonical_name: 'skywalker',
+                active_time_on_site_ms: 1000,
                 event_system_notification_info: {
                     type: 'gdpr_change',
                 },
@@ -759,6 +764,7 @@ describe('Event Server Models', () => {
                 view_controller: 'tv remote',
                 is_main_thread: false,
                 canonical_name: 'skywalker',
+                active_time_on_site_ms: 1000,
                 event_system_notification_info: {
                     type: 'gdpr_change',
                 },
@@ -826,6 +832,7 @@ describe('Event Server Models', () => {
                 view_controller: 'tv remote',
                 is_main_thread: false,
                 canonical_name: 'skywalker',
+                active_time_on_site_ms: 1000,
                 event_system_notification_info: {
                     type: 'gdpr_change',
                 },
@@ -899,6 +906,7 @@ describe('Event Server Models', () => {
                 view_controller: 'tv remote',
                 is_main_thread: false,
                 canonical_name: 'skywalker',
+                active_time_on_site_ms: 1000,
                 event_system_notification_info: {
                     type: 'gdpr_change',
                 },
@@ -936,6 +944,7 @@ describe('Event Server Models', () => {
                 view_controller: 'tv remote',
                 is_main_thread: false,
                 canonical_name: 'skywalker',
+                active_time_on_site_ms: 1000,
                 event_system_notification_info: {
                     type: 'gdpr_change',
                 },
@@ -969,6 +978,7 @@ describe('Event Server Models', () => {
                 view_controller: 'tv remote',
                 is_main_thread: false,
                 canonical_name: 'skywalker',
+                active_time_on_site_ms: 1000,
                 event_system_notification_info: {
                     type: 'gdpr_change',
                 },
@@ -1001,6 +1011,7 @@ describe('Event Server Models', () => {
                 view_controller: 'tv remote',
                 is_main_thread: false,
                 canonical_name: 'skywalker',
+                active_time_on_site_ms: 1000,
                 event_system_notification_info: {
                     type: 'gdpr_change',
                 },
@@ -1058,6 +1069,7 @@ describe('Event Server Models', () => {
                 view_controller: 'tv remote',
                 is_main_thread: false,
                 canonical_name: 'skywalker',
+                active_time_on_site_ms: 1000,
                 event_system_notification_info: {
                     type: 'gdpr_change',
                 },
@@ -1102,6 +1114,7 @@ describe('Event Server Models', () => {
                 view_controller: 'tv remote',
                 is_main_thread: false,
                 canonical_name: 'skywalker',
+                active_time_on_site_ms: 1000,
                 event_system_notification_info: {
                     type: 'gdpr_change',
                 },

--- a/packages/events/tests/index.spec.ts
+++ b/packages/events/tests/index.spec.ts
@@ -245,6 +245,9 @@ describe('Event Server Models', () => {
             batch_id: '12324124',
             mpid: '1300010334',
             sdk_version: 'test.1.223.',
+            partner_identities: {
+                partner_id: 'foo',
+            },
             consent_state: {
                 gdpr: {
                     'Test Purpose': {


### PR DESCRIPTION
## Summary
We need to add `active_time_on_site_ms` since we are updating the DTO 

## Testing Plan


## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-7076