### PR TITLE
feat: Add optional page URL to CommonEventData 

### DIFF
--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/event-models",
-    "version": "1.1.8",
+    "version": "1.2.0",
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -271,6 +271,7 @@ export interface CommonEventData {
     is_main_thread?: boolean;
     canonical_name?: string;
     event_system_notification_info?: EventSystemNotificationInfo;
+    page_url?: string;
 }
 
 export interface ConsentState {


### PR DESCRIPTION
## Summary
- In order for us to capture the location / page an event was fired from this PR adds an optional `page_url`
- This will be used by mParticle/mparticle-web-sdk in order to enrich events with `window.location.href` information before sending it to the mParticle backend
- mParticle server will also be updated to include page url in event DTO

## Testing Plan
- No testing plan for this change in isolation
- Testing will be conducted as part of mParticle/mparticle-web-sdk

## Master Issue
Closes N/A
